### PR TITLE
Add more config options

### DIFF
--- a/config/jjb.ini
+++ b/config/jjb.ini
@@ -1,4 +1,14 @@
 [jenkins]
+# Jenkins url
 url=http://<jenkins-host>:<jenkins-port>
+# User and password for your account on Jenkins
 user=
 password=
+
+[job_builder]
+# If set to True, Jenkins Job Builder won’t use any cache.
+ignore_cache=True
+# By default jenkins-jobs will overwrite the jobs descriptions even if no description has been defined explicitly. When this option is set to True, that behavior changes and it will only overwrite the description if you specified it in the yaml.
+Keep_descriptions=True
+# If set, allows the user to specify if only “jobs” or “views” (or “all”) are updated. Users can override the setting here by passing --jobs-only or --views-only CLI options. (Valid options: jobs, views, all) 
+update=all

--- a/scale-ci-watcher-env.sh
+++ b/scale-ci-watcher-env.sh
@@ -7,7 +7,7 @@ export SCALE_CI_WATCHER_REPO="https://github.com/openshift-scale/scale-ci-pipeli
 # branch to clone
 export SCALE_CI_WATCHER_REPO_BRANCH="master"
 # Location of the scale-ci-watcher repo
-export SCALE_CI_WATCHER_REPO_PATH="/root/scale-ci-pipline"
+export SCALE_CI_WATCHER_REPO_PATH="/root/scale-ci-pipeline"
 # Location of the scale-ci-watcher repo
 export WORKDIR="/root/scale-ci-pipeline"
 # Whether to update the scale-ci jobs or not


### PR DESCRIPTION
This commit add couple of config options for scale-ci-watcher including:
- option to allow jenkins job builder to use cache or not.
- allowing the user to specify if only “jobs” or “views” (or “all”) are
  updated.
- option to keep descriptions in the jobs yaml files.