### PR TITLE
Updated the ansible version on scale-ci labeled slaves

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,12 @@ Here is the list of current scale-ci labeled slaves:
 
 Slaves           | Number of executors | Label            | Ansible version |
 ---------------- | ------------------- | ---------------- | --------------- |
-scale-ci-slave-1 | 3                   | scale-ci         | 2.7.10          |
-scale-ci-slave-2 | 1                   | scale-ci         | 2.7.10          |
-scale-ci-slave-3 | 1                   | scale-ci         | 2.7.10          |
-scale-ci-slave-4 | 3                   | scale-ci         | 2.7.10          |
-scale-ci-slave-5 | 1                   | scale-ci         | 2.7.10          |
-scale-ci-slave-6 | 1                   | scale-ci         | 2.7.10          |
+scale-ci-slave-1 | 3                   | scale-ci         | 2.8.2           |
+scale-ci-slave-2 | 1                   | scale-ci         | 2.8.2           |
+scale-ci-slave-3 | 1                   | scale-ci         | 2.8.2           |
+scale-ci-slave-4 | 3                   | scale-ci         | 2.8.2           |
+scale-ci-slave-5 | 1                   | scale-ci         | 2.8.2           |
+scale-ci-slave-6 | 1                   | scale-ci         | 2.8.2           |
 
 ### Credits
 Thanks to Mary Shakshober for designing the logo.


### PR DESCRIPTION
Ansible 2.8 is needed to run the ocp install job to deploy a cluster
on AWS.