### PR TITLE
Convert sincgars_remote_write_url to a string

### DIFF
--- a/jjb/dynamic/scale-ci_install_aws.yml
+++ b/jjb/dynamic/scale-ci_install_aws.yml
@@ -151,7 +151,7 @@
         description: openshift worker node count.
         name: OPENSHIFT_WORKER_COUNT
     - string:
-        default: "m5.large"
+        default: "m5.xlarge"
         description: openshift master instance type.
         name: OPENSHIFT_MASTER_INSTANCE_TYPE
     - string:
@@ -219,11 +219,11 @@
         description: Machineset label prefix
         name: MACHINESET_METADATA_LABEL_PREFIX
     - string:
-        default: "m5.large"
+        default: "m5.xlarge"
         description: Infra node instance type
         name: OPENSHIFT_INFRA_NODE_INSTANCE_TYPE
     - string:
-        default: "m5.large"
+        default: "m5.xlarge"
         description: Workload node instance type
         name: OPENSHIFT_WORKLOAD_NODE_INSTANCE_TYPE
     - string:

--- a/pipeline-scripts/openshiftv4_on_aws.groovy
+++ b/pipeline-scripts/openshiftv4_on_aws.groovy
@@ -99,7 +99,7 @@ stage ('OCP 4.X INSTALL') {
 						[$class: 'StringParameterValue', name: 'OPENSHIFT_INSTALL_BINARY_URL', value: openshift_install_binary_url ],
 						[$class: 'BooleanParameterValue', name: 'ENABLE_DITTYBOPPER', value: Boolean.valueOf(enable_dittybopper) ],
 						[$class: 'BooleanParameterValue', name: 'ENABLE_REMOTE_WRITE', value: Boolean.valueOf(enable_remote_write) ],
-						[$class: 'StringParameterValue', name: 'SINCGARS_REMOTE_WRITE_URL', value: Boolean.valueOf(sincgars_remote_write_url) ],
+						[$class: 'StringParameterValue', name: 'SINCGARS_REMOTE_WRITE_URL', value: sincgars_remote_write_url ],
 						[$class: 'StringParameterValue', name: 'OPENSHIFT_INSTALL_APIVERSION', value: openshift_install_apiversion ],
 						[$class: 'StringParameterValue', name: 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE', value: openshift_install_ssh_pub_key_file ],
 						[$class: 'hudson.model.PasswordParameterValue', name: 'OPENSHIFT_INSTALL_PULL_SECRET', value: openshift_install_pull_secret ],

--- a/pipeline-scripts/openshiftv4_on_azure.groovy
+++ b/pipeline-scripts/openshiftv4_on_azure.groovy
@@ -95,7 +95,7 @@ stage ('OCP 4.X INSTALL') {
 						[$class: 'StringParameterValue', name: 'OPENSHIFT_INSTALL_BINARY_URL', value: openshift_install_binary_url ],
 						[$class: 'BooleanParameterValue', name: 'ENABLE_DITTYBOPPER', value: Boolean.valueOf(enable_dittybopper) ],
 						[$class: 'BooleanParameterValue', name: 'ENABLE_REMOTE_WRITE', value: Boolean.valueOf(enable_remote_write) ],
-						[$class: 'StringParameterValue', name: 'SINCGARS_REMOTE_WRITE_URL', value: Boolean.valueOf(sincgars_remote_write_url) ],
+						[$class: 'StringParameterValue', name: 'SINCGARS_REMOTE_WRITE_URL', value: sincgars_remote_write_url ],
 						[$class: 'StringParameterValue', name: 'OPENSHIFT_INSTALL_APIVERSION', value: openshift_install_apiversion ],
 						[$class: 'StringParameterValue', name: 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE', value: openshift_install_ssh_pub_key_file ],
 						[$class: 'hudson.model.PasswordParameterValue', name: 'OPENSHIFT_INSTALL_PULL_SECRET', value: openshift_install_pull_secret ],


### PR DESCRIPTION
This commit also changes the node instance type defaults as changed
in https://github.com/openshift-scale/scale-ci-pipeline/pull/52.