### PR TITLE
Rename deployments per ns job

### DIFF
--- a/pipeline-scripts/deployments_per_ns.groovy
+++ b/pipeline-scripts/deployments_per_ns.groovy
@@ -61,7 +61,7 @@ stage ('deployments_per_ns_scale_test') {
 
 			// Run deployments_per_ns job
 			try {
-				deployments_per_ns_build = build job: 'ATS-SCALE-CI-DEPLOYMENTS-PER-NS',
+				deployments_per_ns_build = build job: 'ATS-SCALE-CI-DEPLOYMENTS-PER-NAMESPACE',
 				parameters: [   [$class: 'LabelParameterValue', name: 'node', label: node_label ],
 						[$class: 'BooleanParameterValue', name: 'SKIP_TLS_VERIFICATION', value: Boolean.valueOf(skip_tls) ],
 						[$class: 'StringParameterValue', name: 'CLUSTER_USER', value: cluster_user ],


### PR DESCRIPTION
The build script needs to call the job with the same name as
mentioned in the jjb file.