### PR TITLE
Add retry logic to reconnect and stream logs

### DIFF
--- a/jjb/dynamic/scale-ci_baseline.yml
+++ b/jjb/dynamic/scale-ci_baseline.yml
@@ -32,7 +32,28 @@
         time ansible-playbook -vv -i inventory workloads/baseline.yml
 
         # stream workload pod logs
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-baseline
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-baseline -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-baseline
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
+
         # check the status of the job
         oc get job -n scale-ci-tooling scale-ci-baseline -o json | jq -e '.status.succeeded==1'
     concurrent: true

--- a/jjb/dynamic/scale-ci_conformance.yml
+++ b/jjb/dynamic/scale-ci_conformance.yml
@@ -31,8 +31,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/conformance.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-conformance
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-conformance -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-conformance
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-conformance -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_deployments_per_ns.yml
+++ b/jjb/dynamic/scale-ci_deployments_per_ns.yml
@@ -27,8 +27,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/cluster-limits-deployments-per-ns.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-deployments-per-ns
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-deployments-per-ns -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-deployments-per-ns
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-deployments-per-ns -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_http.yml
+++ b/jjb/dynamic/scale-ci_http.yml
@@ -32,8 +32,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/http.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-http
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-http -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-http
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-http -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_mastervertical.yml
+++ b/jjb/dynamic/scale-ci_mastervertical.yml
@@ -31,8 +31,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/mastervertical.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-mastervertical
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-mastervertical -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-mastervertical
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-mastervertical -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_namespaces_per_cluster.yml
+++ b/jjb/dynamic/scale-ci_namespaces_per_cluster.yml
@@ -32,8 +32,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/cluster-limits-namespaces-per-cluster.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-namespaces-per-cluster
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-namespaces-per-cluster -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-namespaces-per-cluster
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-namespaces-per-cluster -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_nodevertical.yml
+++ b/jjb/dynamic/scale-ci_nodevertical.yml
@@ -32,8 +32,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/nodevertical.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-nodevertical
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-nodevertical -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-nodevertical
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-nodevertical -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_podvertical.yml
+++ b/jjb/dynamic/scale-ci_podvertical.yml
@@ -32,8 +32,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/podvertical.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-podvertical
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-podvertical -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-podvertical
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-podvertical -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_scale.yml
+++ b/jjb/dynamic/scale-ci_scale.yml
@@ -32,8 +32,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/scale.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-scale
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-scale -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-scale
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-scale -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |

--- a/jjb/dynamic/scale-ci_services_per_namespace.yml
+++ b/jjb/dynamic/scale-ci_services_per_namespace.yml
@@ -31,8 +31,29 @@
         ansible --version
         time ansible-playbook -vv -i inventory workloads/cluster-limits-services-per-ns.yml
 
+        # logging
+        logs_counter=0
+        logs_counter_limit=100
         oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-services-per-namespace
+        while true; do
+          logs_counter=$((logs_counter+1))
+          if [[ $(oc get job -n scale-ci-tooling scale-ci-services-per-namespace -o json | jq -e '.status.active==1') == "true" ]]; then
+            if [[ $logs_counter -le $logs_counter_limit ]]; then
+              echo "=================================================================================================================================================================="
+              echo "Attempt $logs_counter to reconnect and fetch the controller pod logs"
+              echo "=================================================================================================================================================================="
+              oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-services-per-namespace
+            else
+              echo "Exceeded the retry limit trying to get the controller logs: $logs_counter_limit, exiting."
+              exit 1
+            fi
+          else
+            echo "Job completed"
+            break
+          fi
+        done
 
+        # status
         oc get job -n scale-ci-tooling scale-ci-services-per-namespace -o json | jq -e '.status.succeeded==1'
     concurrent: true
     description: |


### PR DESCRIPTION
This will cover the cases where the oc logs -f command disconnects/
losses connection with the apiserver to stream the logs. The job will
check the job status and try to stream the logs if it's still active
instead of failing.