### PR TITLE
add scaleup to our periodic pipeline runs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@
 
 def contact = "nelluri@redhat.com"
 def watcher = SCALE_CI_WATCHER.toString().toUpperCase()
+def pipeline = PIPELINE.toString().toUpperCase()
 def build_tracker = SCALE_CI_BUILD_TRACKER.toString().toUpperCase()
 def tooling = TOOLING.toString().toUpperCase()
 def run_conformance = CONFORMANCE.toString().toUpperCase()
@@ -39,142 +40,175 @@ node (node_label) {
 		load "pipeline-scripts/scale_ci_watcher.groovy"
 	}
 
-	// Queries UMB message to capture the OCP 4.x payloads
-	if ( build_tracker == "TRUE") {
-		load "pipeline-scripts/scale_ci_build_tracker.groovy"
+        if (pipeline == "TRUE") {
+		env.PIPELINE_STAGE=1
+		if ( build_tracker == "TRUE") {
+			load "pipeline-scripts/scale_ci_build_tracker.groovy"
+		}
+		if (openshiftv4_install_on_aws == "TRUE") {
+			load "pipeline-scripts/openshiftv4_on_aws.groovy"
+		}
+		if (openshiftv4_install_on_azure == "TRUE") {
+			load "pipeline-scripts/openshiftv4_on_azure.groovy"
+		}
+		if (http == "TRUE") {
+			load "pipeline-scripts/http.groovy"
+		}
+		if (run_uperf == "TRUE") {
+			load "pipeline-scripts/uperf.groovy"
+		}
+		if (ocpv4_scale == "TRUE") {
+                	load "pipeline-scripts/openshiftv4_scale.groovy"
+		}
+
+		env.PIPELINE_STAGE=2
+		if (http == "TRUE") {
+			 load "pipeline-scripts/http.groovy"
+		}
+		if (ocpv4_scale == "TRUE") {
+			load "pipeline-scripts/openshiftv4_scale.groovy"
+		}
+
+	} else {
+
+		// Queries UMB message to capture the OCP 4.x payloads
+		if ( build_tracker == "TRUE") {
+			load "pipeline-scripts/scale_ci_build_tracker.groovy"
+		}
+
+		// stage to install openstack
+		if (install_openstack == "TRUE") {
+			load "pipeline-scripts/openstack.groovy"
+		}
+
+		// stage to set up browbeat
+		if (browbeat == "TRUE") {
+			load "pipeline-scripts/browbeat.groovy"
+		}
+
+		// stage to install openshift 3.x
+		if (openshiftv3_install == "TRUE") {
+			load "pipeline-scripts/openshiftv3.groovy"
+		}
+
+		// stage to install openshift 4.x on AWS
+		if (openshiftv4_install_on_aws == "TRUE") {
+			load "pipeline-scripts/openshiftv4_on_aws.groovy"
+		}
+
+		// stage to install openshift 4.x on Azure
+		if (openshiftv4_install_on_azure == "TRUE") {
+			load "pipeline-scripts/openshiftv4_on_azure.groovy"
+		}
+
+		// stage to setup pbench
+		if (tooling == "TRUE") {
+			load "pipeline-scripts/tooling.groovy"
+		}
+
+		// stage to run conformance
+		if (run_conformance == "TRUE") {
+			load "pipeline-scripts/conformance.groovy"
+		}
+
+		// stage to scaleup the cluster
+		if (ocpv3_scale == "TRUE") {
+			load "pipeline-scripts/openshiftv3_scale.groovy"
+		}
+
+		// stage to run OCP 4.X scaleup
+		if (ocpv4_scale == "TRUE") {
+			load "pipeline-scripts/openshiftv4_scale.groovy"
+		}
+
+		// stage to run nodevertical scale test
+		if (nodevertical == "TRUE") {
+			load "pipeline-scripts/nodevertical.groovy"
+		}
+
+		// stage to run http scale test
+		if (http == "TRUE") {
+			load "pipeline-scripts/http.groovy"
+		}
+
+		// stage to run services per namespace test
+		if (services_per_namespace == "TRUE") {
+			load "pipeline-scripts/services_per_namespace.groovy"
+		}
+
+		// stage to run deployments per ns test
+		if ( deployments_per_ns == "TRUE") {
+			load "pipeline-scripts/deployments_per_ns.groovy"
+		}
+
+		// stage to run podvertical test
+		if ( podvertical == "TRUE") {
+			load "pipeline-scripts/podvertical.groovy"
+		}
+
+		// stage to run networking test
+		if ( networking == "TRUE") {
+			load "pipeline-scripts/networking.groovy"
+		}
+
+		// stage to run pgbench scale test
+		if ( pgbench_test == "TRUE") {
+			load "pipeline-scripts/pgbench.groovy"
+		}
+
+		// stage to run mongodb ycsb scale test
+		if ( mongodb_ycsb_test == "TRUE") {
+			load "pipeline-scripts/mongodbycsb.groovy"
+		}
+
+		// stage to run mastervertical scale test
+		if (mastervertical == "TRUE") {
+			load "pipeline-scripts/mastervertical.groovy"
+		}
+
+		// stage to run ns_per_cluster test
+		if ( ns_per_cluster == "TRUE") {
+			load "pipeline-scripts/ns_per_cluster.groovy"
+		}
+
+		// stage to run logging scale test
+		if (logging == "TRUE") {
+			load "pipeline-scripts/logging.groovy"
+		}
+
+		// stage to run prometheus scale test
+		if ( prometheus_test == "TRUE") {
+			load "pipeline-scripts/prometheus.groovy"
+		}
+
+		// stage to run BYO scale test
+		if (byo == "TRUE") {
+			load "pipeline-scripts/byo.groovy"
+		}
+
+		// stage to run baseline test
+		if (baseline == "TRUE") {
+			load "pipeline-scripts/baseline.groovy"
+		}
+
+		// stage to run uperf test
+		if (run_uperf == "TRUE") {
+			load "pipeline-scripts/uperf.groovy"
+		}
+
 	}
 
-	// stage to install openstack
-	if (install_openstack == "TRUE") {
-		load "pipeline-scripts/openstack.groovy"
-	}
+		// cleanup the workspace
+		stage('cleaning workspace') {
+			deleteDir()
+		}
 
-	// stage to set up browbeat
-	if (browbeat == "TRUE") {
-		load "pipeline-scripts/browbeat.groovy"
-	}
-
-	// stage to install openshift 3.x
-	if (openshiftv3_install == "TRUE") {
-		load "pipeline-scripts/openshiftv3.groovy"
-	}
-
-	// stage to install openshift 4.x on AWS
-	if (openshiftv4_install_on_aws == "TRUE") {
-		load "pipeline-scripts/openshiftv4_on_aws.groovy"
-	}
-
-	// stage to install openshift 4.x on Azure
-	if (openshiftv4_install_on_azure == "TRUE") {
-		load "pipeline-scripts/openshiftv4_on_azure.groovy"
-	}
-
-	// stage to setup pbench
-	if (tooling == "TRUE") {
-		load "pipeline-scripts/tooling.groovy"
-	}
-
-	// stage to run conformance
-	if (run_conformance == "TRUE") {
-		load "pipeline-scripts/conformance.groovy"
-	}
-
-	// stage to scaleup the cluster
-	if (ocpv3_scale == "TRUE") {
-		load "pipeline-scripts/openshiftv3_scale.groovy"
-	}
-
-	// stage to run OCP 4.X scaleup
-	if (ocpv4_scale == "TRUE") {
-		load "pipeline-scripts/openshiftv4_scale.groovy"
-	}
-
-	// stage to run nodevertical scale test
-	if (nodevertical == "TRUE") {
-		load "pipeline-scripts/nodevertical.groovy"
-	}
-
-	// stage to run http scale test
-	if (http == "TRUE") {
-		load "pipeline-scripts/http.groovy"
-	}
-
-	// stage to run services per namespace test
-	if (services_per_namespace == "TRUE") {
-		load "pipeline-scripts/services_per_namespace.groovy"
-	}
-
-	// stage to run deployments per ns test
-	if ( deployments_per_ns == "TRUE" ) {
-		load "pipeline-scripts/deployments_per_ns.groovy"
-	}
-
-	// stage to run podvertical test
-	if ( podvertical == "TRUE" ) {
-		load "pipeline-scripts/podvertical.groovy"
-	}
-
-	// stage to run networking test
-	if ( networking == "TRUE" ) {
-		load "pipeline-scripts/networking.groovy"
-	}
-
-	// stage to run pgbench scale test
-	if ( pgbench_test == "TRUE" ) {
-		load "pipeline-scripts/pgbench.groovy"
-	}
-
-	// stage to run mongodb ycsb scale test
-	if ( mongodb_ycsb_test == "TRUE" ) {
-		load "pipeline-scripts/mongodbycsb.groovy"
-	}
-
-	// stage to run mastervertical scale test
-	if (mastervertical == "TRUE") {
-		load "pipeline-scripts/mastervertical.groovy"
-	}
-
-	// stage to run ns_per_cluster test
-	if ( ns_per_cluster == "TRUE" ) {
-		load "pipeline-scripts/ns_per_cluster.groovy"
-	}
-
-	// stage to run logging scale test
-	if (logging == "TRUE") {
-		load "pipeline-scripts/logging.groovy"
-	}
-
-	// stage to run prometheus scale test
-	if ( prometheus_test == "TRUE" ) {
-		load "pipeline-scripts/prometheus.groovy"
-	}
-
-	// stage to run BYO scale test
-	if (byo == "TRUE") {
-		load "pipeline-scripts/byo.groovy"
-	}
-
-	// stage to run baseline test
-	if (baseline == "TRUE" ) {
-		load "pipeline-scripts/baseline.groovy"
-	}
-
-        // stage to run uperf test
-        if (run_uperf == "TRUE" ) {
-                load "pipeline-scripts/uperf.groovy"
-        }
-
-	// cleanup the workspace
-	stage('cleaning workspace') {
-        	deleteDir()
-	}
-
-	mail(
-		to: contact,
-		subject: "${env.JOB_NAME} ${env.BUILD_NUMBER} completed successfully",
-		body: """\
-			Jenkins job: ${env.BUILD_URL}\n\n
-			See the console output for more details:  ${env.BUILD_URL}consoleFull\n\n
-		"""
-	)
+		mail(
+			to: contact,
+			subject: "${env.JOB_NAME} ${env.BUILD_NUMBER} completed successfully",
+			body: """\
+				Jenkins job: ${env.BUILD_URL}\n\n
+				See the console output for more details:  ${env.BUILD_URL}consoleFull\n\n
+			"""
+		)
 }

--- a/pipeline-scripts/http.groovy
+++ b/pipeline-scripts/http.groovy
@@ -1,107 +1,109 @@
 #!/usr/bin/env groovy
-
 def pipeline_id = env.BUILD_ID
 def node_label = NODE_LABEL.toString()
 def http = HTTP_TEST.toString().toUpperCase()
+def pipeline = PIPELINE.toString().toUpperCase()
 def property_file_name = "http.properties"
-
+def pipeline_stage = env.PIPELINE_STAGE
+println "Current pipeline job stage is '${pipeline_stage}'"
 println "Current pipeline job build id is '${pipeline_id}'"
 
 // run http scale test
 stage ('http_scale_test') {
-	if (http == "TRUE") {
-		currentBuild.result = "SUCCESS"
-		node(node_label) {
-			// get properties file
-			if (fileExists(property_file_name)) {
-				println "Looks like the property file already exists, erasing it"
-				sh "rm ${property_file_name}"
-			}
-			// get properties file
-			sh "wget ${HTTP_TEST_PROPERTY_FILE} -O ${property_file_name}"
-			sh "cat ${property_file_name}"
-			def http_properties = readProperties file: property_file_name
-			def sshkey_token = http_properties['SSHKEY_TOKEN']
-			def orchestration_host = http_properties['ORCHESTRATION_HOST']
-			def orchestration_user = http_properties['ORCHESTRATION_USER']
-			def workload_image = http_properties['WORKLOAD_IMAGE']
-			def workload_job_node_selector = http_properties['WORKLOAD_JOB_NODE_SELECTOR']
-			def workload_job_taint = http_properties['WORKLOAD_JOB_TAINT']
-			def workload_job_privileged = http_properties['WORKLOAD_JOB_PRIVILEGED']
-			def kubeconfig_file = http_properties['KUBECONFIG_FILE']
-			def pbench_instrumentation = http_properties['PBENCH_INSTRUMENTATION']
-			def enable_pbench_agents = http_properties['ENABLE_PBENCH_AGENTS']
-			def enable_pbench_copy = http_properties['ENABLE_PBENCH_COPY']
-			def pbench_server = http_properties['PBENCH_SERVER']
-			def scale_ci_results_token = http_properties['SCALE_CI_RESULTS_TOKEN']
-			def job_completion_poll_attempts = http_properties['JOB_COMPLETION_POLL_ATTEMPTS']
-			def http_test_prefix = http_properties['HTTP_TEST_SUFFIX']
-			def http_test_load_generators = http_properties['HTTP_TEST_LOAD_GENERATORS']
-			def http_test_load_generator_nodes = http_properties['HTTP_TEST_LOAD_GENERATOR_NODES']
-			def http_test_app_projects = http_properties['HTTP_TEST_APP_PROJECTS']
-			def http_test_app_templates = http_properties['HTTP_TEST_APP_TEMPLATES']
-			def http_test_runtime = http_properties['HTTP_TEST_RUNTIME']
-			def http_test_mb_ramp_up = http_properties['HTTP_TEST_MB_RAMP_UP']
-			def http_test_mb_delay = http_properties['HTTP_TEST_MB_DELAY']
-			def http_test_mb_tls_session_reuse = http_properties['HTTP_TEST_MB_TLS_SESSION_REUSE']
-			def http_test_mb_method = http_properties['HTTP_TEST_MB_METHOD']
-			def http_test_mb_response_size = http_properties['HTTP_TEST_MB_RESPONSE_SIZE']
-			def http_test_mb_request_body_size = http_properties['HTTP_TEST_MB_REQUEST_BODY_SIZE']
-			def http_test_route_termination = http_properties['HTTP_TEST_ROUTE_TERMINATION']
-			def http_test_smoke_test = http_properties['HTTP_TEST_SMOKE_TEST']
-			def http_test_namespace_cleanup = http_properties['HTTP_TEST_NAMESPACE_CLEANUP']
-			def http_test_stress_container_image = http_properties['HTTP_TEST_STRESS_CONTAINER_IMAGE']
-			def http_test_server_container_image  = http_properties['HTTP_TEST_SERVER_CONTAINER_IMAGE']
-
-			try {
-				http_build = build job: 'ATS-SCALE-CI-HTTP',
-				parameters: [   [$class: 'LabelParameterValue', name: 'node', label: node_label ],
-						[$class: 'StringParameterValue', name: 'SSHKEY_TOKEN', value: sshkey_token ],
-						[$class: 'StringParameterValue', name: 'ORCHESTRATION_HOST', value: orchestration_host ],
-						[$class: 'StringParameterValue', name: 'ORCHESTRATION_USER', value: orchestration_user ],
-						[$class: 'StringParameterValue', name: 'WORKLOAD_IMAGE', value: workload_image ],
-						[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_NODE_SELECTOR', value: Boolean.valueOf(workload_job_node_selector) ],
-						[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_TAINT', value: Boolean.valueOf(workload_job_taint)  ],
-						[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_PRIVILEGED', value: Boolean.valueOf(workload_job_privileged)  ],
-						[$class: 'StringParameterValue', name: 'KUBECONFIG_FILE', value: kubeconfig_file ],
-						[$class: 'BooleanParameterValue', name: 'PBENCH_INSTRUMENTATION', value: Boolean.valueOf(pbench_instrumentation)  ],
-						[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_AGENTS', value: Boolean.valueOf(enable_pbench_agents)  ],
-						[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_COPY', value: Boolean.valueOf(enable_pbench_copy)  ],
-						[$class: 'StringParameterValue', name: 'PBENCH_SERVER', value: pbench_server ],
-						[$class: 'StringParameterValue', name: 'SCALE_CI_RESULTS_TOKEN', value: scale_ci_results_token ],
-						[$class: 'StringParameterValue', name: 'JOB_COMPLETION_POLL_ATTEMPTS', value: job_completion_poll_attempts ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_SUFFIX', value: http_test_prefix ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_LOAD_GENERATORS', value: http_test_load_generators ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_LOAD_GENERATOR_NODES', value: http_test_load_generator_nodes ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_APP_PROJECTS', value: http_test_app_projects ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_APP_TEMPLATES', value: http_test_app_templates ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_RUNTIME', value: http_test_runtime ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_RAMP_UP', value: http_test_mb_ramp_up ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_DELAY', value: http_test_mb_delay ],
-						[$class: 'BooleanParameterValue', name: 'HTTP_TEST_MB_TLS_SESSION_REUSE', value: Boolean.valueOf(http_test_mb_tls_session_reuse) ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_METHOD', value: http_test_mb_method ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_RESPONSE_SIZE', value: http_test_mb_response_size ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_REQUEST_BODY_SIZE', value: http_test_mb_request_body_size ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_ROUTE_TERMINATION', value: http_test_route_termination ],
-						[$class: 'BooleanParameterValue', name: 'HTTP_TEST_SMOKE_TEST', value: Boolean.valueOf(http_test_smoke_test) ],
-						[$class: 'BooleanParameterValue', name: 'HTTP_TEST_NAMESPACE_CLEANUP', value: Boolean.valueOf(http_test_namespace_cleanup) ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_STRESS_CONTAINER_IMAGE', value: http_test_stress_container_image ],
-						[$class: 'StringParameterValue', name: 'HTTP_TEST_SERVER_CONTAINER_IMAGE', value: http_test_server_container_image ]]
-			} catch ( Exception e) {
-				echo "ATS-SCALE-CI-HTTP Job failed with the following error: "
-				echo "${e.getMessage()}"
-				echo "Sending an email"
-				mail(
-					to: 'msheth@redhat.com',
-					subject: 'ATS-SCALE-CI-HTTP job failed',
-					body: """\
-						Encoutered an error while running the ats-scale-ci-http job: ${e.getMessage()}\n\n
-						Jenkins job: ${env.BUILD_URL}
-				""")
-				currentBuild.result = "FAILURE"
- 				sh "exit 1"
-			}
-			println "ATS-SCALE-CI-HTTP build ${http_build.getNumber()} completed successfully"
+	currentBuild.result = "SUCCESS"
+	node(node_label) {
+		// get properties file
+		if (fileExists(property_file_name)) {
+			println "Looks like the property file already exists, erasing it"
+			sh "rm ${property_file_name}"
 		}
+		// get properties file
+		sh "wget ${HTTP_TEST_PROPERTY_FILE} -O ${property_file_name}"
+		sh "cat ${property_file_name}"
+		def http_properties = readProperties file: property_file_name
+		def sshkey_token = http_properties['SSHKEY_TOKEN']
+		def orchestration_host = http_properties['ORCHESTRATION_HOST']
+		def orchestration_user = http_properties['ORCHESTRATION_USER']
+		def workload_image = http_properties['WORKLOAD_IMAGE']
+		def workload_job_node_selector = http_properties['WORKLOAD_JOB_NODE_SELECTOR']
+		def workload_job_taint = http_properties['WORKLOAD_JOB_TAINT']
+		def workload_job_privileged = http_properties['WORKLOAD_JOB_PRIVILEGED']
+		def kubeconfig_file = http_properties['KUBECONFIG_FILE']
+		def pbench_instrumentation = http_properties['PBENCH_INSTRUMENTATION']
+		def enable_pbench_agents = http_properties['ENABLE_PBENCH_AGENTS']
+		def enable_pbench_copy = http_properties['ENABLE_PBENCH_COPY']
+		def pbench_server = http_properties['PBENCH_SERVER']
+		def scale_ci_results_token = http_properties['SCALE_CI_RESULTS_TOKEN']
+		def job_completion_poll_attempts = http_properties['JOB_COMPLETION_POLL_ATTEMPTS']
+		def http_test_prefix = http_properties['HTTP_TEST_SUFFIX']
+		def http_test_load_generators = http_properties['HTTP_TEST_LOAD_GENERATORS']
+		def http_test_load_generator_nodes = http_properties['HTTP_TEST_LOAD_GENERATOR_NODES']
+		def http_test_app_projects = http_properties['HTTP_TEST_APP_PROJECTS']
+		def http_test_app_templates = http_properties['HTTP_TEST_APP_TEMPLATES']
+		if (pipeline == "TRUE" && pipeline_stage == "2") {
+			http_test_app_templates = http_properties['HTTP_TEST_APP_TEMPLATES_LARGE']
+		}
+		def http_test_runtime = http_properties['HTTP_TEST_RUNTIME']
+		def http_test_mb_ramp_up = http_properties['HTTP_TEST_MB_RAMP_UP']
+		def http_test_mb_delay = http_properties['HTTP_TEST_MB_DELAY']
+		def http_test_mb_tls_session_reuse = http_properties['HTTP_TEST_MB_TLS_SESSION_REUSE']
+		def http_test_mb_method = http_properties['HTTP_TEST_MB_METHOD']
+		def http_test_mb_response_size = http_properties['HTTP_TEST_MB_RESPONSE_SIZE']
+		def http_test_mb_request_body_size = http_properties['HTTP_TEST_MB_REQUEST_BODY_SIZE']
+		def http_test_route_termination = http_properties['HTTP_TEST_ROUTE_TERMINATION']
+		def http_test_smoke_test = http_properties['HTTP_TEST_SMOKE_TEST']
+		def http_test_namespace_cleanup = http_properties['HTTP_TEST_NAMESPACE_CLEANUP']
+		def http_test_stress_container_image = http_properties['HTTP_TEST_STRESS_CONTAINER_IMAGE']
+		def http_test_server_container_image  = http_properties['HTTP_TEST_SERVER_CONTAINER_IMAGE']
+
+		try {
+			http_build = build job: 'ATS-SCALE-CI-HTTP',
+			parameters: [   [$class: 'LabelParameterValue', name: 'node', label: node_label ],
+					[$class: 'StringParameterValue', name: 'SSHKEY_TOKEN', value: sshkey_token ],
+					[$class: 'StringParameterValue', name: 'ORCHESTRATION_HOST', value: orchestration_host ],
+					[$class: 'StringParameterValue', name: 'ORCHESTRATION_USER', value: orchestration_user ],
+					[$class: 'StringParameterValue', name: 'WORKLOAD_IMAGE', value: workload_image ],
+					[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_NODE_SELECTOR', value: Boolean.valueOf(workload_job_node_selector) ],
+					[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_TAINT', value: Boolean.valueOf(workload_job_taint)  ],
+					[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_PRIVILEGED', value: Boolean.valueOf(workload_job_privileged)  ],
+					[$class: 'StringParameterValue', name: 'KUBECONFIG_FILE', value: kubeconfig_file ],
+					[$class: 'BooleanParameterValue', name: 'PBENCH_INSTRUMENTATION', value: Boolean.valueOf(pbench_instrumentation)  ],
+					[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_AGENTS', value: Boolean.valueOf(enable_pbench_agents)  ],
+					[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_COPY', value: Boolean.valueOf(enable_pbench_copy)  ],
+					[$class: 'StringParameterValue', name: 'PBENCH_SERVER', value: pbench_server ],
+					[$class: 'StringParameterValue', name: 'SCALE_CI_RESULTS_TOKEN', value: scale_ci_results_token ],
+					[$class: 'StringParameterValue', name: 'JOB_COMPLETION_POLL_ATTEMPTS', value: job_completion_poll_attempts ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_SUFFIX', value: http_test_prefix ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_LOAD_GENERATORS', value: http_test_load_generators ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_LOAD_GENERATOR_NODES', value: http_test_load_generator_nodes ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_APP_PROJECTS', value: http_test_app_projects ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_APP_TEMPLATES', value: http_test_app_templates ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_RUNTIME', value: http_test_runtime ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_RAMP_UP', value: http_test_mb_ramp_up ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_DELAY', value: http_test_mb_delay ],
+					[$class: 'BooleanParameterValue', name: 'HTTP_TEST_MB_TLS_SESSION_REUSE', value: Boolean.valueOf(http_test_mb_tls_session_reuse) ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_METHOD', value: http_test_mb_method ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_RESPONSE_SIZE', value: http_test_mb_response_size ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_MB_REQUEST_BODY_SIZE', value: http_test_mb_request_body_size ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_ROUTE_TERMINATION', value: http_test_route_termination ],
+					[$class: 'BooleanParameterValue', name: 'HTTP_TEST_SMOKE_TEST', value: Boolean.valueOf(http_test_smoke_test) ],
+					[$class: 'BooleanParameterValue', name: 'HTTP_TEST_NAMESPACE_CLEANUP', value: Boolean.valueOf(http_test_namespace_cleanup) ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_STRESS_CONTAINER_IMAGE', value: http_test_stress_container_image ],
+					[$class: 'StringParameterValue', name: 'HTTP_TEST_SERVER_CONTAINER_IMAGE', value: http_test_server_container_image ]]
+		} catch ( Exception e) {
+			echo "ATS-SCALE-CI-HTTP Job failed with the following error: "
+			echo "${e.getMessage()}"
+			echo "Sending an email"
+			mail(
+				to: 'msheth@redhat.com',
+				subject: 'ATS-SCALE-CI-HTTP job failed',
+				body: """\
+					Encoutered an error while running the ats-scale-ci-http job: ${e.getMessage()}\n\n
+					Jenkins job: ${env.BUILD_URL}
+			""")
+			currentBuild.result = "FAILURE"
+			sh "exit 1"
+		}
+		println "ATS-SCALE-CI-HTTP build ${http_build.getNumber()} completed successfully"
 	}
 }

--- a/pipeline-scripts/openshiftv4_scale.groovy
+++ b/pipeline-scripts/openshiftv4_scale.groovy
@@ -3,81 +3,86 @@
 def pipeline_id = env.BUILD_ID
 def node_label = NODE_LABEL.toString()
 def ocpv4_scale = OPENSHIFTv4_SCALE.toString().toUpperCase()
+def pipeline = PIPELINE.toString().toUpperCase()
 def property_file_name = "openshiftv4_scale.properties"
-
+def pipeline_stage = env.PIPELINE_STAGE
+println "Current pipeline job stage is '${pipeline_stage}'"
 println "Current pipeline job build id is '${pipeline_id}'"
 
 // 4.x scale cluster
 stage ('4.x scale cluster') {
-	if (ocpv4_scale  == "TRUE") {
-		currentBuild.result = "SUCCESS"
-		node(node_label) {
-			// get properties file
-			if (fileExists(property_file_name)) {
-				println "Looks like the property file already exists, erasing it"
-				sh "rm ${property_file_name}"
-			}
-			// get properties file
-			sh "wget ${OPENSHIFTv4_SCALE_PROPERTY_FILE} -O ${property_file_name}"
-			sh "cat ${property_file_name}"
-			def scale_properties = readProperties file: property_file_name
-			def sshkey_token = scale_properties['SSHKEY_TOKEN']
-			def orchestration_host = scale_properties['ORCHESTRATION_HOST']
-			def orchestration_user = scale_properties['ORCHESTRATION_USER']
-			def workload_image = scale_properties['WORKLOAD_IMAGE']
-			def workload_job_node_selector = scale_properties['WORKLOAD_JOB_NODE_SELECTOR']
-			def workload_job_taint = scale_properties['WORKLOAD_JOB_TAINT']
-			def workload_job_privileged = scale_properties['WORKLOAD_JOB_PRIVILEGED']
-			def kubeconfig_file = scale_properties['KUBECONFIG_FILE']
-			def pbench_instrumentation = scale_properties['PBENCH_INSTRUMENTATION']
-			def enable_pbench_agents = scale_properties['ENABLE_PBENCH_AGENTS']
-			def enable_pbench_copy = scale_properties['ENABLE_PBENCH_COPY']
-			def pbench_server = scale_properties['PBENCH_SERVER']
-			def scale_ci_results_token = scale_properties['SCALE_CI_RESULTS_TOKEN']
-			def job_completion_poll_attempts = scale_properties['JOB_COMPLETION_POLL_ATTEMPTS']
-			def scale_test_prefix = scale_properties['SCALE_TEST_PREFIX']
-			def scale_metadata_prefix = scale_properties['SCALE_METADATA_PREFIX']
-			def scale_worker_count = scale_properties['SCALE_WORKER_COUNT']
-			def scale_poll_attempts = scale_properties['SCALE_POLL_ATTEMPTS']
-			def expected_scale_duration = scale_properties['EXPECTED_SCALE_DURATION']
-
-			try {
-				scale_build = build job: 'ATS-SCALE-CI-SCALE',
-				parameters: [   [$class: 'LabelParameterValue', name: 'node', label: node_label ],
-						[$class: 'StringParameterValue', name: 'SSHKEY_TOKEN', value: sshkey_token ],
-						[$class: 'StringParameterValue', name: 'ORCHESTRATION_HOST', value: orchestration_host ],
-						[$class: 'StringParameterValue', name: 'ORCHESTRATION_USER', value: orchestration_user ],
-						[$class: 'StringParameterValue', name: 'WORKLOAD_IMAGE', value: workload_image ],
-						[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_NODE_SELECTOR', value: Boolean.valueOf(workload_job_node_selector) ],
-						[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_TAINT', value: Boolean.valueOf(workload_job_taint)  ],
-						[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_PRIVILEGED', value: Boolean.valueOf(workload_job_privileged)  ],
-						[$class: 'StringParameterValue', name: 'KUBECONFIG_FILE', value: kubeconfig_file ],
-						[$class: 'BooleanParameterValue', name: 'PBENCH_INSTRUMENTATION', value: Boolean.valueOf(pbench_instrumentation)  ],
-						[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_AGENTS', value: Boolean.valueOf(enable_pbench_agents)  ],
-						[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_COPY', value: Boolean.valueOf(enable_pbench_copy)  ],
-						[$class: 'StringParameterValue', name: 'PBENCH_SERVER', value: pbench_server ],
-						[$class: 'StringParameterValue', name: 'SCALE_CI_RESULTS_TOKEN', value: scale_ci_results_token ],
-						[$class: 'StringParameterValue', name: 'JOB_COMPLETION_POLL_ATTEMPTS', value: job_completion_poll_attempts ],
-						[$class: 'StringParameterValue', name: 'SCALE_TEST_PREFIX', value: scale_test_prefix ],
-						[$class: 'StringParameterValue', name: 'SCALE_METADATA_PREFIX', value: scale_metadata_prefix  ],
-						[$class: 'StringParameterValue', name: 'SCALE_WORKER_COUNT', value: scale_worker_count ],
-						[$class: 'StringParameterValue', name: 'SCALE_POLL_ATTEMPTS', value: scale_poll_attempts ],
-						[$class: 'StringParameterValue', name: 'EXPECTED_SCALE_DURATION', value: expected_scale_duration ]]
-			} catch ( Exception e) {
-				echo "ATS-SCALE-CI-SCALE Job failed with the following error: "
-				echo "${e.getMessage()}"
-				echo "Sending an email"
-				mail(
-					to: 'nelluri@redhat.com',
-					subject: 'ATS-SCALE-CI-SCALE job failed',
-					body: """\
-						Encoutered an error while running the ats-scale-ci-scale job: ${e.getMessage()}\n\n
-						Jenkins job: ${env.BUILD_URL}
-				""")
-				currentBuild.result = "FAILURE"
- 				sh "exit 1"
-			}
-			println "ATS-SCALE-CI-SCALE build ${scale_build.getNumber()} completed successfully"
+	currentBuild.result = "SUCCESS"
+	node(node_label) {
+		// get properties file
+		if (fileExists(property_file_name)) {
+			println "Looks like the property file already exists, erasing it"
+			sh "rm ${property_file_name}"
 		}
+		// get properties file
+		sh "wget ${OPENSHIFTv4_SCALE_PROPERTY_FILE} -O ${property_file_name}"
+		sh "cat ${property_file_name}"
+		def scale_properties = readProperties file: property_file_name
+		def sshkey_token = scale_properties['SSHKEY_TOKEN']
+		def orchestration_host = scale_properties['ORCHESTRATION_HOST']
+		def orchestration_user = scale_properties['ORCHESTRATION_USER']
+		def workload_image = scale_properties['WORKLOAD_IMAGE']
+		def workload_job_node_selector = scale_properties['WORKLOAD_JOB_NODE_SELECTOR']
+		def workload_job_taint = scale_properties['WORKLOAD_JOB_TAINT']
+		def workload_job_privileged = scale_properties['WORKLOAD_JOB_PRIVILEGED']
+		def kubeconfig_file = scale_properties['KUBECONFIG_FILE']
+		def pbench_instrumentation = scale_properties['PBENCH_INSTRUMENTATION']
+		def enable_pbench_agents = scale_properties['ENABLE_PBENCH_AGENTS']
+		def enable_pbench_copy = scale_properties['ENABLE_PBENCH_COPY']
+		def pbench_server = scale_properties['PBENCH_SERVER']
+		def scale_ci_results_token = scale_properties['SCALE_CI_RESULTS_TOKEN']
+		def job_completion_poll_attempts = scale_properties['JOB_COMPLETION_POLL_ATTEMPTS']
+		def scale_test_prefix = scale_properties['SCALE_TEST_PREFIX']
+		def scale_metadata_prefix = scale_properties['SCALE_METADATA_PREFIX']
+		def scale_worker_count = scale_properties['SCALE_WORKER_COUNT']
+		if (pipeline == "TRUE" && pipeline_stage == "2") {
+			scale_worker_count = scale_properties['SCALE_WORKER_COUNT_V2']
+		} else if (pipeline == "TRUE" && pipeline_stage == "3") {
+			scale_worker_count = scale_properties['SCALE_WORKER_COUNT_V3']
+		}
+		def scale_poll_attempts = scale_properties['SCALE_POLL_ATTEMPTS']
+		def expected_scale_duration = scale_properties['EXPECTED_SCALE_DURATION']
+
+		try {
+			scale_build = build job: 'ATS-SCALE-CI-SCALE',
+			parameters: [   [$class: 'LabelParameterValue', name: 'node', label: node_label ],
+					[$class: 'StringParameterValue', name: 'SSHKEY_TOKEN', value: sshkey_token ],
+					[$class: 'StringParameterValue', name: 'ORCHESTRATION_HOST', value: orchestration_host ],
+					[$class: 'StringParameterValue', name: 'ORCHESTRATION_USER', value: orchestration_user ],
+					[$class: 'StringParameterValue', name: 'WORKLOAD_IMAGE', value: workload_image ],
+					[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_NODE_SELECTOR', value: Boolean.valueOf(workload_job_node_selector) ],
+					[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_TAINT', value: Boolean.valueOf(workload_job_taint)  ],
+					[$class: 'BooleanParameterValue', name: 'WORKLOAD_JOB_PRIVILEGED', value: Boolean.valueOf(workload_job_privileged)  ],
+					[$class: 'StringParameterValue', name: 'KUBECONFIG_FILE', value: kubeconfig_file ],
+					[$class: 'BooleanParameterValue', name: 'PBENCH_INSTRUMENTATION', value: Boolean.valueOf(pbench_instrumentation)  ],
+					[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_AGENTS', value: Boolean.valueOf(enable_pbench_agents)  ],
+					[$class: 'BooleanParameterValue', name: 'ENABLE_PBENCH_COPY', value: Boolean.valueOf(enable_pbench_copy)  ],
+					[$class: 'StringParameterValue', name: 'PBENCH_SERVER', value: pbench_server ],
+					[$class: 'StringParameterValue', name: 'SCALE_CI_RESULTS_TOKEN', value: scale_ci_results_token ],
+					[$class: 'StringParameterValue', name: 'JOB_COMPLETION_POLL_ATTEMPTS', value: job_completion_poll_attempts ],
+					[$class: 'StringParameterValue', name: 'SCALE_TEST_PREFIX', value: scale_test_prefix ],
+					[$class: 'StringParameterValue', name: 'SCALE_METADATA_PREFIX', value: scale_metadata_prefix  ],
+					[$class: 'StringParameterValue', name: 'SCALE_WORKER_COUNT', value: scale_worker_count ],
+					[$class: 'StringParameterValue', name: 'SCALE_POLL_ATTEMPTS', value: scale_poll_attempts ],
+					[$class: 'StringParameterValue', name: 'EXPECTED_SCALE_DURATION', value: expected_scale_duration ]]
+		} catch ( Exception e) {
+			echo "ATS-SCALE-CI-SCALE Job failed with the following error: "
+			echo "${e.getMessage()}"
+			echo "Sending an email"
+			mail(
+				to: 'nelluri@redhat.com',
+				subject: 'ATS-SCALE-CI-SCALE job failed',
+				body: """\
+					Encoutered an error while running the ats-scale-ci-scale job: ${e.getMessage()}\n\n
+					Jenkins job: ${env.BUILD_URL}
+			""")
+			currentBuild.result = "FAILURE"
+			sh "exit 1"
+		}
+		println "ATS-SCALE-CI-SCALE build ${scale_build.getNumber()} completed successfully"
 	}
 }


### PR DESCRIPTION
This will give us the ability to runs tests after scaleup/scaledown in one go.
Currently our pipelines is not stable and hence the user will have to check PIPELINE and the subsequent test boxes. Once we have stability across the board we can just have PIPELINE to be checked for the entire run

test run with http->uperf->scaleup->http->scaledown
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/scale-ci-pipeline-test/253/console
@chaitanyaenr @jtaleric 