### PR TITLE
[WIP] Adding kraken to Scale-CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ def networking = NETWORKING.toString().toUpperCase()
 def byo = BYO_SCALE_TEST.toString().toUpperCase()
 def baseline = BASELINE_SCALE_TEST.toString().toUpperCase()
 def run_uperf = UPERF.toString().toUpperCase()
+def kraken = KRAKEN.toString().toUpperCase()
 def node_label = NODE_LABEL.toString()
 
 node (node_label) {
@@ -41,7 +42,7 @@ node (node_label) {
 		load "pipeline-scripts/scale_ci_watcher.groovy"
 	}
 
-        if (pipeline == "TRUE") {
+	if (pipeline == "TRUE") {
 		env.PIPELINE_STAGE=1
 		if ( build_tracker == "TRUE") {
 			load "pipeline-scripts/scale_ci_build_tracker.groovy"
@@ -53,8 +54,8 @@ node (node_label) {
 			load "pipeline-scripts/openshiftv4_on_azure.groovy"
 		}
 		if (openshiftv4_install_on_gcp == "TRUE") {
-                        load "pipeline-scripts/openshiftv4_on_gcp.groovy"
-                }
+			load "pipeline-scripts/openshiftv4_on_gcp.groovy"
+		}
 		if (http == "TRUE") {
 			load "pipeline-scripts/http.groovy"
 		}
@@ -62,7 +63,7 @@ node (node_label) {
 			load "pipeline-scripts/uperf.groovy"
 		}
 		if (ocpv4_scale == "TRUE") {
-                	load "pipeline-scripts/openshiftv4_scale.groovy"
+			load "pipeline-scripts/openshiftv4_scale.groovy"
 		}
 
 		env.PIPELINE_STAGE=2
@@ -110,11 +111,11 @@ node (node_label) {
 		if (openshiftv4_install_on_azure == "TRUE") {
 			load "pipeline-scripts/openshiftv4_on_azure.groovy"
 		}
-		
+
 		// stage to install openshift 4.x on GCP
-                if (openshiftv4_install_on_gcp == "TRUE") {
-                        load "pipeline-scripts/openshiftv4_on_gcp.groovy"
-                }
+		if (openshiftv4_install_on_gcp == "TRUE") {
+			load "pipeline-scripts/openshiftv4_on_gcp.groovy"
+		}
 
 		// stage to setup pbench
 		if (tooling == "TRUE") {
@@ -209,6 +210,11 @@ node (node_label) {
 		// stage to run uperf test
 		if (run_uperf == "TRUE") {
 			load "pipeline-scripts/uperf.groovy"
+		}
+
+		// stage to run kraken test
+		if (kraken == "TRUE") {
+			load "pipeline-scripts/kraken.groovy"
 		}
 
 	}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Services per namespace | Cluster Limits | Tests maximum number of services possi
 Namespaces per cluster | Cluster Limits | Tests namespaces per cluster limit | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |  
 Baseline | Base/Idle cluster | Captures performance data of the base cluster with no user created objects | :heavy_check_mark: | NA | :heavy_check_mark: |
 Uperf | Networking | uperf benchmarks testing node to node, pod to pod, and svc to svc throughput and latency for TCP and UDP protocols | :heavy_check_mark: | :x: | :heavy_check_mark: |
+Kraken | Base/Idle cluster | Injects chaos scenarios into the cluster | :heavy_check_mark: | NA | :heavy_check_mark: |
 ### Modifying/Adding new workloads to the scale-ci-pipeline
 
 Adding new workloads is managed by scale-ci-watcher and it expects the following:

--- a/jjb/dynamic/scale-ci_kraken.yml
+++ b/jjb/dynamic/scale-ci_kraken.yml
@@ -1,0 +1,145 @@
+- job:
+    block-downstream: false
+    block-upstream: false
+    builders:
+    - shell: |+
+        set -euxo pipefail
+
+        git clone https://${SSHKEY_TOKEN}@github.com/redhat-performance/perf-dept.git
+        export PUBLIC_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2.pub
+        export PRIVATE_KEY=${WORKSPACE}/perf-dept/ssh_keys/id_rsa_pbench_ec2
+        chmod 600 ${PRIVATE_KEY}
+
+        cd ansible
+
+        # Create inventory File:
+        echo "[orchestration]" > inventory
+        echo "${ORCHESTRATION_HOST}" >> inventory
+
+        time ansible-playbook -vv -i inventory kraken.yml
+    concurrent: true
+    description: This job runs Kraken workload
+    disabled: false
+    name: kraken
+    node: scale-ci
+    parameters:
+    - string:
+        default: ""
+        description: The machine into which chaos scenarios are to be injected.
+        name: ORCHESTRATION_HOST
+        trim: 'false'
+    - string:
+        default: "root"
+        description: The user for the Orchestration host.
+        name: ORCHESTRATION_USER
+        trim: 'false'
+    - string:
+        default: ""
+        description: Token to access private repo containing ssh keys.
+        name: SSHKEY_TOKEN
+        trim: 'false'
+    - string:
+        default: "/root/.kube/config"
+        description: Location of kubeconfig on orchestration host.
+        name: KUBECONFIG_PATH
+        trim: 'false'
+    - string:
+        default: "/root/kraken"
+        description: Kraken dir location on jump host.
+        name: KRAKEN_DIR
+        trim: 'false'
+    - string:
+        default: "/root/kraken/config/config.yaml"
+        description: Kraken config path location.
+        name: KRAKEN_CONFIG
+        trim: 'false'
+    - string:
+        default: "https://github.com/yashashreesuresh/kraken.git"
+        description: Kraken repository location.
+        name: KRAKEN_REPOSITORY
+        trim: 'false'
+    - string:
+        default: "CI/scenarios/"
+        description: Chaos scenarios folder path.
+        name: SCENARIOS_FOLDER_PATH
+        trim: 'false'
+    - string:
+        default: "[[scenarios/etcd.yml, scenarios/post_action_etcd_example.sh], [scenarios/openshift-apiserver.yml, scenarios/post_action_openshift-kube-apiserver.yml], [scenarios/openshift-kube-apiserver.yml, scenarios/post_action_openshift-apiserver.yml], [scenarios/regex_openshift_pod_kill.yml, scenarios/post_action_regex.py]]"
+        description: Chaos scenarios to inject.
+        name: SCENARIOS
+        trim: 'false'
+    - bool:
+        default: false
+        description: Exit when a post action scenario fails.
+        name: EXIT_ON_FAILURE
+    - bool:
+        default: false
+        description: Kraken repository location.
+        name: CERBERUS_ENABLED
+    - string:
+        default: ""
+        description: url where true/false signal from Cerberus can be accessed.
+        name: CERBERUS_URL
+    - string:
+        default: "60"
+        description: Duration to wait between each chaos scenario.
+        name: WAIT_DURATION
+    - string:
+        default: "1"
+        description: Number of times to execute the scenarios.
+        name: ITERATIONS
+    - bool:
+        default: false
+        description: Iterations are set to infinity which means that chaos scenarios are injected forever.
+        name: DAEMON_MODE
+    project-type: freestyle
+    properties:
+    - raw:
+        xml: |
+          <hudson.plugins.disk__usage.DiskUsageProperty plugin="disk-usage@0.28" />
+    - raw:
+        xml: |
+          <com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty plugin="gitlab-plugin@1.5.3">
+          <gitLabConnection />
+          </com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty>
+    - raw:
+        xml: |
+          <org.jenkinsci.plugins.ZMQEventPublisher.HudsonNotificationProperty plugin="zmq-event-publisher@0.0.5">
+          <enabled>false</enabled>
+          </org.jenkinsci.plugins.ZMQEventPublisher.HudsonNotificationProperty>
+    - raw:
+        xml: |
+          <com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty plugin="ownership@0.11.0">
+          <ownership>
+          <ownershipEnabled>true</ownershipEnabled>
+          <primaryOwnerId>nelluri</primaryOwnerId>
+          <coownersIds class="sorted-set" />
+          </ownership>
+          </com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty>
+    - raw:
+        xml: |
+          <com.sonyericsson.rebuild.RebuildSettings plugin="rebuild@1.27">
+          <autoRebuild>false</autoRebuild>
+          <rebuildDisabled>false</rebuildDisabled>
+          </com.sonyericsson.rebuild.RebuildSettings>
+    - raw:
+        xml:
+          <hudson.plugins.throttleconcurrents.ThrottleJobProperty plugin="throttle-concurrents@2.0.1">
+          <maxConcurrentPerNode>0</maxConcurrentPerNode>
+          <maxConcurrentTotal>0</maxConcurrentTotal>
+          <categories class="java.util.concurrent.CopyOnWriteArrayList" />
+          <throttleEnabled>false</throttleEnabled>
+          <throttleOption>project</throttleOption>
+          <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
+          <paramsToUseForLimit />
+          </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
+    publishers: []
+    scm:
+    - git:
+        branches:
+        - '*/master'
+        url: https://github.com/openshift-scale/kraken.git
+    triggers: []
+    wrappers:
+    - workspace-cleanup:
+        dirmatch: false

--- a/jjb/static/scale-ci-pipeline.yml
+++ b/jjb/static/scale-ci-pipeline.yml
@@ -117,6 +117,10 @@
         default: false
         description: ''
         name: UPERF
+    - bool:
+        default: false
+        description: ''
+        name: KRAKEN
     - string:
         default: ''
         description: ''
@@ -232,6 +236,9 @@
         default: ''
         description: ''
         name: UPERF_PROPERTIES_FILE
+    - string:
+        default: ''
+        name: KRAKEN_PROPERTY_FILE
     - string:
         default: 'scale-ci'
         description: ''

--- a/pipeline-scripts/kraken.groovy
+++ b/pipeline-scripts/kraken.groovy
@@ -1,0 +1,76 @@
+#!/usr/bin/env groovy
+
+def pipeline_id = env.BUILD_ID
+def node_label = NODE_LABEL.toString()
+def kraken = KRAKEN.toString().toUpperCase()
+def property_file_name = "kraken.properties"
+
+println "Current pipeline job build id is '${pipeline_id}'"
+
+// run kraken
+stage ('kraken') {
+	if (kraken == "TRUE") {
+		currentBuild.result = "SUCCESS"
+		node(node_label) {
+			// get properties file
+			if (fileExists(property_file_name)) {
+				println "Looks like the property file already exists, erasing it"
+				sh "rm ${property_file_name}"
+			}
+			// get properties file
+			sh "wget ${KRAKEN_PROPERTY_FILE} -O ${property_file_name}"
+			sh "cat ${property_file_name}"
+			def kraken_properties = readProperties file: property_file_name
+			def orchestration_host = kraken_properties['ORCHESTRATION_HOST']
+			def orchestration_user = kraken_properties['ORCHESTRATION_USER']
+			def sshkey_token = kraken_properties['SSHKEY_TOKEN']
+			def kubeconfig_path = kraken_properties['KUBECONFIG_PATH']
+			def kraken_dir = kraken_properties['KRAKEN_DIR']
+			def kraken_config = kraken_properties['KRAKEN_CONFIG']
+			def kraken_repository = kraken_properties['KRAKEN_REPOSITORY']
+			def scenarios_folder_path = kraken_properties['SCENARIOS_FOLDER_PATH']
+			def scenarios = kraken_properties['SCENARIOS']
+			def exit_on_failure = kraken_properties['EXIT_ON_FAILURE']
+			def cerberus_enabled = kraken_properties['CERBERUS_ENABLED']
+			def cerberus_url = kraken_properties['CERBERUS_URL']
+			def wait_duration = kraken_properties['WAIT_DURATION']
+			def iterations = kraken_properties['ITERATIONS']
+			def daemon_mode = kraken_properties['DAEMON_MODE']
+
+			// Run kraken job
+			try {
+				kraken_build = build job: 'kraken',
+				parameters: [   [$class: 'LabelParameterValue', name: 'node', label: node_label ],
+						[$class: 'StringParameterValue', name: 'ORCHESTRATION_HOST', value: orchestration_host ],
+						[$class: 'StringParameterValue', name: 'ORCHESTRATION_USER', value: orchestration_user ],
+						[$class: 'StringParameterValue', name: 'SSHKEY_TOKEN', value: sshkey_token ],
+						[$class: 'StringParameterValue', name: 'KUBECONFIG_PATH', value: kubeconfig_path ],
+						[$class: 'StringParameterValue', name: 'KRAKEN_DIR', value: kraken_dir ],
+						[$class: 'StringParameterValue', name: 'KRAKEN_CONFIG', value: kraken_config ],
+						[$class: 'StringParameterValue', name: 'KRAKEN_REPOSITORY', value: kraken_repository ],
+						[$class: 'StringParameterValue', name: 'SCENARIOS_FOLDER_PATH', value: scenarios_folder_path ],
+						[$class: 'StringParameterValue', name: 'SCENARIOS', value: scenarios ],
+						[$class: 'BooleanParameterValue', name: 'EXIT_ON_FAILURE', value: Boolean.valueOf(exit_on_failure) ],
+						[$class: 'BooleanParameterValue', name: 'CERBERUS_ENABLED', value: Boolean.valueOf(cerberus_enabled) ],
+						[$class: 'StringParameterValue', name: 'CERBERUS_URL', value: cerberus_url ],
+						[$class: 'StringParameterValue', name: 'WAIT_DURATION', value: wait_duration ],
+						[$class: 'StringParameterValue', name: 'ITERATIONS', value: iterations ],
+						[$class: 'BooleanParameterValue', name: 'DAEMON_MODE', value: Boolean.valueOf(daemon_mode) ]]
+			} catch ( Exception e) {
+				echo "kraken Job failed with the following error: "
+				echo "${e.getMessage()}"
+				echo "Sending an email"
+				mail(
+					to: 'nelluri@redhat.com',
+					subject: 'kraken job failed',
+					body: """\
+						Encoutered an error while running the kraken job: ${e.getMessage()}\n\n
+						Jenkins job: ${env.BUILD_URL}
+				""")
+				currentBuild.result = "FAILURE"
+ 				sh "exit 1"
+			}
+			println "kraken build ${kraken_build.getNumber()} completed successfully"
+		}
+	}
+}

--- a/properties-files/kraken.properties
+++ b/properties-files/kraken.properties
@@ -1,0 +1,15 @@
+ORCHESTRATION_HOST=
+ORCHESTRATION_USER=root
+SSHKEY_TOKEN=
+KUBECONFIG_PATH=/root/.kube/config
+KRAKEN_DIR=/root/kraken
+KRAKEN_CONFIG=/root/kraken/config/config.yaml
+KRAKEN_REPOSITORY=https://github.com/openshift-scale/kraken.git
+SCENARIOS_FOLDER_PATH=CI/scenarios/
+SCENARIOS=[[scenarios/etcd.yml, scenarios/post_action_etcd_example.sh], [scenarios/openshift-apiserver.yml, scenarios/post_action_openshift-kube-apiserver.yml], [scenarios/openshift-kube-apiserver.yml, scenarios/post_action_openshift-apiserver.yml], [scenarios/regex_openshift_pod_kill.yml, scenarios/post_action_regex.py]]
+EXIT_ON_FAILURE=false
+CERBERUS_ENABLED=false
+CERBERUS_URL=
+WAIT_DURATION=60
+ITERATIONS=1
+DAEMON_MODE=false


### PR DESCRIPTION
This commit:

- Adds a kraken template which will be managed by scale-ci-watcher.
  Kraken workload allows us to inject chaos scenarios into the cluster. 
  Thereby helps in determining cluster's resilience.

- Adds a sample properties file to kick off the Job.
