### PR TITLE
Update watcher job with new param

### DIFF
--- a/jjb/dynamic/scale-ci_watcher.yml
+++ b/jjb/dynamic/scale-ci_watcher.yml
@@ -8,6 +8,7 @@
         export SCALE_CI_WATCHER_REPO_PATH=$WORKSPACE
         export JJB_CONFIG_PATH=$WORKSPACE/config/jjb.ini
         export WORKDIR=$WORKSPACE
+        export WATCHER_TARGET_DIRECTORY=$WORKSPACE/jjb/dynamic
 
         # Setup config to talk to Jenkins api
         sed -i "/user/c \user=$JENKINS_USER" $JJB_CONFIG_PATH
@@ -15,7 +16,6 @@
         sed -i "/url/c \url=$JENKINS_URL" $JJB_CONFIG_PATH
 
         # Run the watcher
-        cd $SCALE_CI_WATCHER_REPO_PATH
         export PYTHONHTTPSVERIFY=0; ./scale-ci-watcher.sh
     concurrent: false
     disabled: false

--- a/pipeline-scripts/scale_ci_watcher.groovy
+++ b/pipeline-scripts/scale_ci_watcher.groovy
@@ -22,7 +22,6 @@ stage ('SCALE-CI-WATCHER') {
 			}
 			// get properties file
 			sh "wget ${SCALE_CI_WATCHER_PROPERTY_FILE} -O ${property_file_name}"
-			sh "cat ${property_file_name}"
 			def watcher_properties = readProperties file: property_file_name
 			def url = watcher_properties['JENKINS_URL']
 			def config = watcher_properties['JJB_CONFIG_PATH']


### PR DESCRIPTION
This commit also updates the watcher build script to not print the
properties file to the stdout to avoid exposing the jenkins API
credentials.