### PR TITLE
skip failed stages in a certain cases

### DIFF
--- a/pipeline-scripts/http.groovy
+++ b/pipeline-scripts/http.groovy
@@ -136,9 +136,12 @@ stage ('http_scale_test') {
 					Encoutered an error while running the ats-scale-ci-http job: ${e.getMessage()}\n\n
 					Jenkins job: ${env.BUILD_URL}
 			""")
-			currentBuild.result = "FAILURE"
-			sh "exit 1"
+                        if(pipeline){
+                           unstable('ATS-SCALE-CI-HTTP job FAILED, moving on to next job in the pipeline')
+                        } else{
+                           currentBuild.result = "FAILURE"
+                        }
 		}
-		println "ATS-SCALE-CI-HTTP build ${http_build.getNumber()} completed successfully"
+		println "ATS-SCALE-CI-HTTP build completed with status ${currentBuild.result}"
 	}
 }

--- a/pipeline-scripts/uperf.groovy
+++ b/pipeline-scripts/uperf.groovy
@@ -4,6 +4,7 @@ def pipeline_id = env.BUILD_ID
 def node_label = NODE_LABEL.toString()
 def run_uperf = UPERF.toString().toUpperCase()
 def property_file_name = "uperf.properties"
+def pipeline = PIPELINE.toString().toUpperCase()
 
 println "Current pipeline job build id is '${pipeline_id}'"
 
@@ -97,10 +98,13 @@ stage ('uperf') {
 						Encoutered an error while running the uperf job: ${e.getMessage()}\n\n
 						Jenkins job: ${env.BUILD_URL}
 				""")
-				currentBuild.result = "FAILURE"
-				sh "exit 1"
+                                if(pipeline){
+                                unstable('RIPSAW-UPERF job FAILED, moving on to next job in the pipeline')
+                                } else{
+                                currentBuild.result = "FAILURE"
+                                }
 			}
-			println "UPERF build ${uperf_build.getNumber()} completed successfully"
+			println "UPERF build completed with status ${currentBuild.result}"
 		}
 	}
 }


### PR DESCRIPTION
with this commit if http or uperf job fails the pipeline will go ahead with the next job.
Not introducing this for control plane tests yet:
-  as we might want to investigate into the failure

- if we go ahead with the next test (scale down) even if there is a failure; there might be too many objects for the nodes to handle

Proposed solution:
(checkbox) A comprehensive cleanup job that runs after a job failure