### PR TITLE
add multiple stages to scaleup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,11 @@
 def contact = "nelluri@redhat.com"
 def watcher = SCALE_CI_WATCHER.toString().toUpperCase()
 def pipeline = PIPELINE.toString().toUpperCase()
+def stage_two = STAGE_TWO.toString().toUpperCase()
+def stage_three = STAGE_THREE.toString().toUpperCase()
+def stage_four = STAGE_FOUR.toString().toUpperCase()
+def stage_five = STAGE_FIVE.toString().toUpperCase()
+def stage_six = STAGE_SIX.toString().toUpperCase()
 def build_tracker = SCALE_CI_BUILD_TRACKER.toString().toUpperCase()
 def tooling = TOOLING.toString().toUpperCase()
 def run_conformance = CONFORMANCE.toString().toUpperCase()
@@ -70,22 +75,61 @@ node (node_label) {
 		if (ocpv4_scale == "TRUE") {
 			load "pipeline-scripts/openshiftv4_scale.groovy"
 		}
+		
+		if (stage_two == "TRUE") {
+			env.PIPELINE_STAGE=2
+			if (http == "TRUE") {
+				load "pipeline-scripts/http.groovy"
+			}
+			if (kubelet_density == "TRUE") {
+				load "pipeline-scripts/kubelet_density.groovy"
+			}
+			if (cluster_density == "TRUE") {
+				load "pipeline-scripts/cluster_density.groovy"
+			}
+			if (ocpv4_scale == "TRUE") {
+				load "pipeline-scripts/openshiftv4_scale.groovy"
+			}
+		}
 
-		env.PIPELINE_STAGE=2
-		if (http == "TRUE") {
-			load "pipeline-scripts/http.groovy"
+		if (stage_three == "TRUE") {
+			env.PIPELINE_STAGE=3
+			if (cluster_density == "TRUE") {
+				load "pipeline-scripts/cluster_density.groovy"
+			}
+			if (ocpv4_scale == "TRUE") {
+ 				load "pipeline-scripts/openshiftv4_scale.groovy"
+			}
+ 		}
+
+		if (stage_four == "TRUE") {
+			env.PIPELINE_STAGE=4
+			if (cluster_density == "TRUE") {
+				load "pipeline-scripts/cluster_density.groovy"
+			}
+			if (ocpv4_scale == "TRUE") {
+				load "pipeline-scripts/openshiftv4_scale.groovy"
+			}
 		}
-		if (cluster_density == "TRUE") {
-			load "pipeline-scripts/cluster-density.groovy"
+
+		if (stage_five == "TRUE") {
+			env.PIPELINE_STAGE=5
+			if (cluster_density == "TRUE") {
+				load "pipeline-scripts/cluster_density.groovy"
+			}
+			if (ocpv4_scale == "TRUE") {
+				load "pipeline-scripts/openshiftv4_scale.groovy"
+			}
 		}
-		if (kubelet_density == "TRUE") {
-			load "pipeline-scripts/kubelet-density.groovy"
-		}
-		if (kubelet_density_light == "TRUE") {
-			load "pipeline-scripts/kubelet-density-light.groovy"
-		}
-		if (ocpv4_scale == "TRUE") {
-			load "pipeline-scripts/openshiftv4_scale.groovy"
+
+		if (stage_six == "TRUE") {
+			env.PIPELINE_STAGE=6
+			if (cluster_density == "TRUE") {
+				load "pipeline-scripts/cluster_density.groovy"
+			}
+ 			if (ocpv4_scale == "TRUE") {
+				load "pipeline-scripts/openshiftv4_scale.groovy"
+			}
 		}
 
 	} else {

--- a/jjb/static/scale-ci-pipeline.yml
+++ b/jjb/static/scale-ci-pipeline.yml
@@ -1,7 +1,6 @@
 - job:
     concurrent: true
-    description: 'Collection of Jenkins jobs to install, configure, scaleup ocp and run various performance and scale
-      tests on OpenShift across various public and private clouds. '
+    description: 'Collection of Jenkins jobs to install, configure, scaleup ocp and run various performance and scale tests on OpenShift across various public and private clouds. '
     disabled: false
     name: SCALE-CI-PIPELINE
     parameters:
@@ -13,6 +12,26 @@
         default: false
         description: ''
         name: PIPELINE
+    - bool:
+        default: true
+        description: 'runs router, object-density, cluster-density workloads typically at 25 node scale'
+        name: STAGE_TWO
+    - bool:
+        default: false
+        description: 'runs cluster-density workload typically at 100 node scale'
+        name: STAGE_THREE
+    - bool:
+        default: false
+        description: 'runs cluster-density workload typically at 250 node scale'
+        name: STAGE_FOUR
+    - bool:
+        default: false
+        description: 'runs cluster-density workload typically at 500 node scale'
+        name: STAGE_FIVE
+    - bool:
+        default: false
+        description: 'runs cluster-density workload typically at 1000 node scale'
+        name: STAGE_SIX
     - bool:
         default: false
         description: ''
@@ -301,4 +320,4 @@
           <paramsToUseForLimit />
           </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
     triggers:
-    - timed: '0 10 * * 1,3,5'
+    - timed: '0 01 * * 1,3,5'

--- a/pipeline-scripts/cluster-density.groovy
+++ b/pipeline-scripts/cluster-density.groovy
@@ -27,6 +27,15 @@ stage ('cluster-density') {
 			def qps = cluster_density_properties['QPS']
 			def burst = cluster_density_properties['BURST']
 			def job_iterations = cluster_density_properties['JOB_ITERATIONS']
+			if (pipeline == "TRUE" && pipeline_stage == "3") {
+￼				job_iterations = cluster_density_properties['JOB_ITERATIONS_V2']
+￼			} else if (pipeline == "TRUE" && pipeline_stage == "4") {
+￼				job_iterations = cluster_density_properties['JOB_ITERATIONS_V3']
+￼			} else if (pipeline == "TRUE" && pipeline_stage == "5") {
+￼				job_iterations = cluster_density_properties['JOB_ITERATIONS_V4']
+￼			} else if (pipeline == "TRUE" && pipeline_stage == "6") {
+￼				job_iterations = cluster_density_properties['JOB_ITERATIONS_V5']
+￼			}
 			def es_server = cluster_density_properties['ES_SERVER']
 			def es_port = cluster_density_properties['ES_PORT']
 			def es_index = cluster_density_properties['ES_INDEX']

--- a/pipeline-scripts/openshiftv4_scale.groovy
+++ b/pipeline-scripts/openshiftv4_scale.groovy
@@ -35,6 +35,12 @@ stage ('4.x scale cluster') {
 			scale = scale_properties['SCALE_V2']
 		} else if (pipeline == "TRUE" && pipeline_stage == "3") {
 			scale = scale_properties['SCALE_V3']
+		} else if (pipeline == "TRUE" && pipeline_stage == "4") {
+			scale = scale_properties['SCALE_V4']
+		} else if (pipeline == "TRUE" && pipeline_stage == "5") {
+			scale = scale_properties['SCALE_V5']
+		} else if (pipeline == "TRUE" && pipeline_stage == "6") {
+			scale = scale_properties['SCALE_V6']
 		}
 		def es_user = scale_properties['ES_USER']
 		def es_password = scale_properties['ES_PASSWORD']


### PR DESCRIPTION
add a checkbox to include stages we want to touch during our pipeline run,
(for ex.
stage_two = scale to 25 nodes
stage_hree = 100 nodes
stage_four = 250
stage_five = 500
stage_six = 1000)
yes, all of the above # of nodes can be passed through properties file

[tested](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/scale-ci-pipeline-test/501/console) with the below properties file
```
SCALE=3
SCALE_V2=2
SCALE_V3=4
SCALE_V4=3
SCALE_V5=6
SCALE_V6=3
```