### PR TITLE
Added extension in cluster_status readFile

### DIFF
--- a/pipeline-scripts/openshiftv4_on_osp.groovy
+++ b/pipeline-scripts/openshiftv4_on_osp.groovy
@@ -107,7 +107,7 @@ stage ('OCP 4.X INSTALL') {
 				sh "curl ${scale_ci_build_trigger_url}/build.status -o /tmp/status.osp"
 				sh "curl ${scale_ci_build_trigger_url}/cluster.status -o /tmp/cluster_status.osp"
 				status = readFile "/tmp/status.osp"
-				cluster_status = readFile "/tmp/cluster_status"
+				cluster_status = readFile "/tmp/cluster_status.osp"
 				if ( status.toString().trim().equals("PROCEED") || cluster_status.toString().trim().equals("False") ) {
 					println "Build status is set to ${status}, proceeding with the cluster build"
 					openshift_install_release_image_override = readFile "/tmp/payload.osp"


### PR DESCRIPTION
The extension shouldn't matter much but good to have since
we have multiple platforms running in CI and we might want
to avoid some other platform job changing the same file.