### PR TITLE
removing the benchamrk-status state

### DIFF
--- a/jjb/dynamic/uperf.yml
+++ b/jjb/dynamic/uperf.yml
@@ -20,9 +20,9 @@
         export KUBECONFIG=${WORKSPACE}/kubeconfig
 
         # delete benchmark status file if exists and set the path
-        rm /tmp/uperf_$BUILD_NUMBER.status || true
-        export BENCHMARK_STATUS_PATH=/tmp/uperf_$BUILD_NUMBER.status
-        echo "BENCHMARK_STATUS_FILE=$BENCHMARK_STATUS_PATH" > uperf.properties
+        #rm /tmp/uperf_$BUILD_NUMBER.status || true
+        #export BENCHMARK_STATUS_PATH=/tmp/uperf_$BUILD_NUMBER.status
+        #echo "BENCHMARK_STATUS_FILE=$BENCHMARK_STATUS_PATH" > uperf.properties
 
         # run tests
         pushd workloads/network-perf/
@@ -31,18 +31,18 @@
         fi
         if [[ ${HOSTNETWORK_TEST} == "true" ]] ; then
           ./run_hostnetwork_network_test_fromgit.sh test_cloud $KUBECONFIG
-          hostnetwork_test_status=$(oc get benchmarks/uperf-benchmark-hostnetwork  -n my-ripsaw -o jsonpath='{.status.state}')
-          echo "hostnetwork_test=$hostnetwork_test_status" >> /tmp/uperf_$BUILD_NUMBER.status
+         #hostnetwork_test_status=$(oc get benchmarks/uperf-benchmark-hostnetwork  -n my-ripsaw -o jsonpath='{.status.state}')
+         #echo "hostnetwork_test=$hostnetwork_test_status" >> /tmp/uperf_$BUILD_NUMBER.status
         fi
         if [[ ${POD_TEST} == "true" ]] ; then
           ./run_pod_network_test_fromgit.sh test_cloud $KUBECONFIG
-          podnetwork_test_status=$(oc get benchmarks/uperf-benchmark-pod-network  -n my-ripsaw -o jsonpath='{.status.state}')
-          echo "podnetwork_test=$hostnetwork_test_status" >> /tmp/uperf_$BUILD_NUMBER.status
+          #podnetwork_test_status=$(oc get benchmarks/uperf-benchmark-pod-network  -n my-ripsaw -o jsonpath='{.status.state}')
+          #echo "podnetwork_test=$hostnetwork_test_status" >> /tmp/uperf_$BUILD_NUMBER.status
         fi
         if [[ ${SERVICE_TEST} == "true" ]] ; then
           ./run_serviceip_network_test_fromgit.sh test_cloud $KUBECONFIG
-          servicenetwork_test_status=$(oc get benchmarks/uperf-benchmark-service-network  -n my-ripsaw -o jsonpath='{.status.state}')
-          echo "servicenetwork_test=$servicenetwork_test_status" >> /tmp/uperf_$BUILD_NUMBER.status
+          #servicenetwork_test_status=$(oc get benchmarks/uperf-benchmark-service-network  -n my-ripsaw -o jsonpath='{.status.state}')
+          #echo "servicenetwork_test=$servicenetwork_test_status" >> /tmp/uperf_$BUILD_NUMBER.status
         fi
     concurrent: true
     description: |-


### PR DESCRIPTION
we can skip indexing the benchmark status for uperf for now as pod and service benchmark have 3 iterations each (1,2,4 pairs) and we are indexing only the last one.
Commenting out this for now as we need a better logic for this.
This commit will also solve the uperf failure[ here ](https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/RIPSAW-UPERF/289/console)