### PR TITLE
avoid string matching with the actual variables

### DIFF
--- a/config/jjb.ini
+++ b/config/jjb.ini
@@ -1,7 +1,7 @@
 [jenkins]
-# Jenkins url
+# Jenkins URL
 url=http://<jenkins-host>:<jenkins-port>
-# User and password for your account on Jenkins
+# USER and PASSOWRD for your account on Jenkins
 user=
 password=
 


### PR DESCRIPTION
there are duplicate ```url=https://jenkins.com``` and ```password=blahblahblah``` in the jjb.ini
https://github.com/openshift-scale/scale-ci-pipeline/blob/f3a99de85750328d1ec2a335b19f5e537df87a01/jjb/dynamic/scale-ci_watcher.yml#L13-L16 
This commit will solve it